### PR TITLE
Restore the PRESENTS subtitle under the Game Freak logo in the intro animation

### DIFF
--- a/engine/movie/intro.asm
+++ b/engine/movie/intro.asm
@@ -327,6 +327,14 @@ PlayShootingStar:
 	; A `call LoadPresentsGraphic` here was removed in localization
 	pop af
 	jr c, .next ; skip the delay if the user interrupted the animation
+	hlcoord 7, 11   ; starting coordinate
+	ld a, $67       ; starting tile ID
+	ld c, $06       ; number of tiles
+.loop
+	ld [hli], a
+	inc a
+	dec c
+	jr nz, .loop
 	ld c, 40
 	call DelayFrames
 .next


### PR DESCRIPTION
Restore the "PRESENTS" under the Game Freak logo in the intro, restoring it to how it was in the original Red and Green