### PR TITLE
Improve the Pokédex AREA functionality

### DIFF
--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -2934,6 +2934,8 @@ CheckMapForMon:
 	ld a, c
 	ld [de], a
 	inc de
+	inc hl
+	ret
 .nextEntry
 	inc hl
 	inc hl


### PR DESCRIPTION
Prevent a buffer overflow in the Pokédex area function when more than 30 of the same species exist