### PR TITLE
Avoid using `EQUS` when `EQU` or `MACRO` will do (#496)

### DIFF
--- a/engine/gfx/mon_icons.asm
+++ b/engine/gfx/mon_icons.asm
@@ -283,13 +283,13 @@ INCLUDE "data/pokemon/menu_icons.asm"
 DEF INC_FRAME_1 EQUS "0, $20"
 DEF INC_FRAME_2 EQUS "$20, $20"
 
-BugIconFrame1:       INCBIN "gfx/icons/bug.2bpp", INC_FRAME_1
-PlantIconFrame1:     INCBIN "gfx/icons/plant.2bpp", INC_FRAME_1
-BugIconFrame2:       INCBIN "gfx/icons/bug.2bpp", INC_FRAME_2
-PlantIconFrame2:     INCBIN "gfx/icons/plant.2bpp", INC_FRAME_2
-SnakeIconFrame1:     INCBIN "gfx/icons/snake.2bpp", INC_FRAME_1
+BugIconFrame1:       INCBIN "gfx/icons/bug.2bpp",       INC_FRAME_1
+PlantIconFrame1:     INCBIN "gfx/icons/plant.2bpp",     INC_FRAME_1
+BugIconFrame2:       INCBIN "gfx/icons/bug.2bpp",       INC_FRAME_2
+PlantIconFrame2:     INCBIN "gfx/icons/plant.2bpp",     INC_FRAME_2
+SnakeIconFrame1:     INCBIN "gfx/icons/snake.2bpp",     INC_FRAME_1
 QuadrupedIconFrame1: INCBIN "gfx/icons/quadruped.2bpp", INC_FRAME_1
-SnakeIconFrame2:     INCBIN "gfx/icons/snake.2bpp", INC_FRAME_2
+SnakeIconFrame2:     INCBIN "gfx/icons/snake.2bpp",     INC_FRAME_2
 QuadrupedIconFrame2: INCBIN "gfx/icons/quadruped.2bpp", INC_FRAME_2
 
 TradeBubbleIconGFX:  INCBIN "gfx/trade/bubble.2bpp"

--- a/macros/coords.asm
+++ b/macros/coords.asm
@@ -11,9 +11,17 @@ MACRO validate_coords
 	ENDC
 ENDM
 
-DEF hlcoord EQUS "coord hl,"
-DEF bccoord EQUS "coord bc,"
-DEF decoord EQUS "coord de,"
+MACRO hlcoord
+	coord hl, \#
+ENDM
+
+MACRO bccoord
+	coord bc, \#
+ENDM
+
+MACRO decoord
+	coord de, \#
+ENDM
 
 MACRO coord
 ; register, x, y[, origin]
@@ -25,9 +33,17 @@ MACRO coord
 	ENDC
 ENDM
 
-DEF hlbgcoord EQUS "bgcoord hl,"
-DEF bcbgcoord EQUS "bgcoord bc,"
-DEF debgcoord EQUS "bgcoord de,"
+MACRO hlbgcoord
+	bgcoord hl, \#
+ENDM
+
+MACRO bcbgcoord
+	bgcoord bc, \#
+ENDM
+
+MACRO debgcoord
+	bgcoord de, \#
+ENDM
 
 MACRO bgcoord
 ; register, x, y[, origin]
@@ -39,9 +55,17 @@ MACRO bgcoord
 	ENDC
 ENDM
 
-DEF hlowcoord EQUS "owcoord hl,"
-DEF bcowcoord EQUS "owcoord bc,"
-DEF deowcoord EQUS "owcoord de,"
+MACRO hlowcoord
+	owcoord hl, \#
+ENDM
+
+MACRO bcowcoord
+	owcoord bc, \#
+ENDM
+
+MACRO deowcoord
+	owcoord de, \#
+ENDM
 
 MACRO owcoord
 ; register, x, y, map width

--- a/macros/scripts/maps.asm
+++ b/macros/scripts/maps.asm
@@ -225,8 +225,14 @@ MACRO connection
 	dw wOverworldMap + _win
 ENDM
 
-DEF def_script_pointers EQUS "const_def"
+MACRO def_script_pointers
+	const_def
+ENDM
 
-DEF def_text_pointers EQUS "const_def 1"
+MACRO def_text_pointers
+	const_def 1
+ENDM
 
-DEF object_const_def EQUS "const_def 1"
+MACRO object_const_def
+	const_def 1
+ENDM

--- a/macros/scripts/text.asm
+++ b/macros/scripts/text.asm
@@ -1,13 +1,38 @@
-DEF text   EQUS "db TX_START,"    ; Start writing text.
-DEF next   EQUS "db \"<NEXT>\","  ; Move a line down.
-DEF line   EQUS "db \"<LINE>\","  ; Start writing at the bottom line.
-DEF para   EQUS "db \"<PARA>\","  ; Start a new paragraph.
-DEF cont   EQUS "db \"<CONT>\","  ; Scroll to the next line.
-DEF done   EQUS "db \"<DONE>\""   ; End a text box.
-DEF prompt EQUS "db \"<PROMPT>\"" ; Prompt the player to end a text box (initiating some other event).
+MACRO text
+	db TX_START, \# ; Start writing text
+ENDM
 
-DEF page   EQUS "db \"<PAGE>\","         ; Start a new Pokédex page.
-DEF dex    EQUS "db \"<DEXEND>\", \"@\"" ; End a Pokédex entry.
+MACRO next
+	db "<NEXT>", \# ; Move a line down
+ENDM
+
+MACRO line
+	db "<LINE>", \# ; Start writing at the bottom line
+ENDM
+
+MACRO para
+	db "<PARA>", \# ; Start a new paragraph
+ENDM
+
+MACRO cont
+	db "<CONT>", \# ; Scroll to the next line
+ENDM
+
+MACRO done
+	db "<DONE>" ; End a text box
+ENDM
+
+MACRO prompt
+	db "<PROMPT>" ; Prompt the player to end a text box (initiating some other event)
+ENDM
+
+MACRO page
+	db "<PAGE>", \# ; Start a new Pokédex page
+ENDM
+
+MACRO dex
+	db "<DEXEND>@" ; End a Pokédex entry
+ENDM
 
 
 ; TextCommandJumpTable indexes (see home/text.asm)


### PR DESCRIPTION
Based on https://github.com/pret/pokecrystal/pull/1166